### PR TITLE
Breadcrumb update

### DIFF
--- a/client/components/Breadcrumb.vue
+++ b/client/components/Breadcrumb.vue
@@ -39,8 +39,9 @@
             async updateBreadcrumbs() {
                 // TODO: will need some rework when we'll have more complex paths, especially splitPaths()
                 const currentPath = this.$route.path;
+                const availableRoutes = this.$router.options.routes;
                 const paths = this.splitPaths(currentPath);
-                const routes = paths.map(path => this.$router.options.routes.find(route => route.path === path));
+                const routes = paths.map(path => availableRoutes.find(route => route.path === path));
                 this.breadcrumbs = await this.getTitles(routes);
             },
             splitPaths(path) {
@@ -60,7 +61,7 @@
             getTitles(routes) {
                 const crumbs = [];
                 let i = 0;
-                const promises = routes.map(route => {
+                const promises = routes.map((route) => {
                     const crumb = {
                         index: i++
                     };

--- a/client/components/Breadcrumb.vue
+++ b/client/components/Breadcrumb.vue
@@ -38,6 +38,8 @@
         methods: {
             async updateBreadcrumbs() {
                 // TODO: will need some rework when we'll have more complex paths, especially splitPaths()
+                // TODO: also, this function should be called when updating the route (so probably beforeRouteEnter and beforeRouteUpdate)
+                //  TODO: and when changing the parent's page title (this.pageTitle = ...), we should probably emit an event and react to it here and re-generate the crumbs
                 const currentPath = this.$route.path;
                 const availableRoutes = this.$router.options.routes;
                 const paths = this.splitPaths(currentPath);
@@ -67,12 +69,12 @@
                     };
                     return route.component()
                         .then((component) => {
-                            const head = (component.head && component.head());
-                            const title = (head && head.title) || route.name;
+                            const headTitle = component.head && component.head() && component.head().title;
+                            const dataTitle = component.data && component.data() && component.data().pageTitle;
                             crumbs.push({
                                 ...crumb,
                                 path: route.path,
-                                name: title
+                                name: headTitle || dataTitle || route.name
                             });
                         });
                 });

--- a/client/components/Breadcrumb.vue
+++ b/client/components/Breadcrumb.vue
@@ -2,11 +2,12 @@
     <b-row>
         <b-col>
             <el-breadcrumb separator="/">
-                <el-breadcrumb-item :to="{ path: '/' }">homepage</el-breadcrumb-item>
+                <el-breadcrumb-item :to="{ path: '/' }">Home</el-breadcrumb-item>
                 <el-breadcrumb-item
-                    v-for="item in items"
-                    :key="item.id"
-                    :to="{ path: item.path }">{{ item.name }}</el-breadcrumb-item>
+                    v-for="item in breadcrumbs"
+                    :key="item.index"
+                    :to="{ path: item.path }">{{ item.name }}
+                </el-breadcrumb-item>
             </el-breadcrumb>
         </b-col>
     </b-row>
@@ -17,7 +18,68 @@
         props: {
             items: {
                 type: Array,
+                required: false,
                 default: null
+            }
+        },
+        data() {
+            return {
+                breadcrumbs: [],
+            };
+        },
+        async mounted() {
+            if (this.items) {
+                this.breadcrumbs = this.items;
+            }
+            else {
+                await this.updateBreadcrumbs();
+            }
+        },
+        methods: {
+            async updateBreadcrumbs() {
+                // TODO: will need some rework when we'll have more complex paths, especially splitPaths()
+                const currentPath = this.$route.path;
+                const paths = this.splitPaths(currentPath);
+                const routes = paths.map(path => this.$router.options.routes.find(route => route.path === path));
+                this.breadcrumbs = await this.getTitles(routes);
+            },
+            splitPaths(path) {
+                let p = path;
+                let i;
+                const paths = [];
+
+                do {
+                    paths.push(p);
+                    i = p.lastIndexOf('/');
+                    p = p.substring(0, i);
+                } while (p !== '');
+
+                paths.reverse();
+                return paths;
+            },
+            getTitles(routes) {
+                const crumbs = [];
+                let i = 0;
+                const promises = routes.map(route => {
+                    const crumb = {
+                        index: i++
+                    };
+                    return route.component()
+                        .then((component) => {
+                            const head = (component.head && component.head());
+                            const title = (head && head.title) || route.name;
+                            crumbs.push({
+                                ...crumb,
+                                path: route.path,
+                                name: title
+                            });
+                        });
+                });
+                return Promise.all(promises)
+                    .then(() => {
+                        crumbs.sort((a, b) => a.index - b.index);
+                        return crumbs;
+                    });
             }
         }
     };

--- a/client/pages/admin/index.vue
+++ b/client/pages/admin/index.vue
@@ -13,8 +13,13 @@
     export default {
         head() {
             return {
-                title: 'Admin page'
+                title: this.pageTitle
             };
         },
+        data() {
+            return {
+                pageTitle: 'Admin page'
+            };
+        }
     };
 </script>

--- a/client/pages/admin/index.vue
+++ b/client/pages/admin/index.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <app-breadcrumb :items="breadcrumbItems" />
+        <app-breadcrumb />
         <b-row>
             <b-col>
                 <h1>Welcome, admin</h1>
@@ -13,16 +13,8 @@
     export default {
         head() {
             return {
-                title: this.title
+                title: 'Admin page'
             };
         },
-        data() {
-            return {
-                title: 'Admin page',
-                breadcrumbItems: [
-                    { id: 0, name: 'admin', path: null }
-                ]
-            };
-        }
     };
 </script>

--- a/client/pages/admin/list/index.vue
+++ b/client/pages/admin/list/index.vue
@@ -41,11 +41,12 @@
 export default {
     head() {
         return {
-            title: 'Users'
+            title: this.pageTitle
         };
     },
     data() {
         return {
+            pageTitle: 'Users',
             users: [],
         };
     },

--- a/client/pages/admin/list/index.vue
+++ b/client/pages/admin/list/index.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <app-breadcrumb :items="breadcrumbItems" />
+        <app-breadcrumb />
         <b-row>
             <b-col>
                 <h1>Users</h1>
@@ -47,10 +47,6 @@ export default {
     data() {
         return {
             users: [],
-            breadcrumbItems: [
-                { id: 0, name: 'admin', path: '/admin' },
-                { id: 1, name: 'list all users', path: '/admin/list' }
-            ]
         };
     },
     async mounted() {

--- a/client/pages/admin/register/index.vue
+++ b/client/pages/admin/register/index.vue
@@ -62,11 +62,12 @@
 export default {
     head() {
         return {
-            title: 'Register'
+            title: this.pageTitle
         };
     },
     data() {
         return {
+            pageTitle: 'Register',
             form: {
                 name: '',
                 surname: '',

--- a/client/pages/admin/register/index.vue
+++ b/client/pages/admin/register/index.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <app-breadcrumb :items="breadcrumbItems" />
+        <app-breadcrumb />
         <b-row>
             <b-col>
                 <h1>Register new user</h1>
@@ -131,10 +131,6 @@ export default {
                     }
                 ]
             },
-            breadcrumbItems: [
-                { id: 0, name: 'admin', path: '/admin' },
-                { id: 1, name: 'register new user', path: '/admin/register' }
-            ]
         };
     },
     methods: {

--- a/client/pages/index.vue
+++ b/client/pages/index.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <app-breadcrumb :items="breadcrumbItems" />
+        <app-breadcrumb :items="breadcrumbs" />
         <b-row>
             <b-col>
                 <h1>Welcome, user</h1>
@@ -13,14 +13,13 @@
     export default {
         head() {
             return {
-                title: this.title
+                title: 'Dashboard'
             };
         },
         data() {
             return {
-                title: 'Dashboard',
-                breadcrumbItems: [
-                    { id: 0, name: 'dashboard', path: null }
+                breadcrumbs: [
+                    { index: 0, name: 'dashboard', path: null }
                 ]
             };
         }

--- a/client/pages/index.vue
+++ b/client/pages/index.vue
@@ -13,11 +13,12 @@
     export default {
         head() {
             return {
-                title: 'Dashboard'
+                title: this.pageTitle
             };
         },
         data() {
             return {
+                pageTitle: 'Dashboard',
                 breadcrumbs: [
                     { index: 0, name: 'dashboard', path: null }
                 ]


### PR DESCRIPTION
Probably isn't perfect and will probably break when we have complex paths, but for now it's ok.

If `Breadcrumb` component **has** `items` prop specified, it will use it (please use `index` property instead of `id` now as keys for the `<el-breadcrumb-item>` components) preferably.

If `Breadcrumb` component **doesn't** have `items` prop specified, it will construct the breadcrumbs on its own:
1. get current path (e.g. `/admin/list`)
2. since Nuxt generates paths quite predictably, we can assume that the previous route would be `/admin` (`/` is handled manually) - HERE it will probably break, considering we can have routes like `/project/1/task/2/edit` or whatever
3. for each found path, look up the route corresponding to the path
4. access its assigned component, read its `head()` and `title` in it
5. should it fail, fall back to *route* name (which is also generated, so that shouldn't be null or empty)
